### PR TITLE
fix: configure Mend to scan master branch and trigger rescan

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,6 +1,6 @@
 {
   "scanSettings": {
-    "baseBranches": []
+    "baseBranches": ["master"]
   },
   "checkRunSettings": {
     "vulnerableCheckRunConclusionLevel": "failure",


### PR DESCRIPTION
The baseBranches was empty [], preventing the Mend bot from rescanning the default branch and auto-closing resolved vulnerability issues (#533-541, #545, #547, #549, #587, #588).

https://claude.ai/code/session_01EpLiESJNgAxrbjeKZ95q8p